### PR TITLE
Fixing issue where image in launch screen was improperly scaled to its container

### DIFF
--- a/Diabetes/Startup/LaunchScreen.xib
+++ b/Diabetes/Startup/LaunchScreen.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14B23" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -10,7 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo_disease_large" translatesAutoresizingMaskIntoConstraints="NO" id="yIY-au-BzP">
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo_disease_large" translatesAutoresizingMaskIntoConstraints="NO" id="yIY-au-BzP">
                     <rect key="frame" x="100" y="224" width="120" height="120"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="120" id="br1-iX-V6W"/>
@@ -29,6 +29,6 @@
         </view>
     </objects>
     <resources>
-        <image name="logo_disease_large" width="240" height="240"/>
+        <image name="logo_disease_large" width="102" height="128"/>
     </resources>
 </document>


### PR DESCRIPTION
Was set to scaleToFit, not scaleAspectFit.
